### PR TITLE
Update index.js

### DIFF
--- a/lib/renderer/markdown-it-prism/index.js
+++ b/lib/renderer/markdown-it-prism/index.js
@@ -73,14 +73,31 @@ module.exports = function (md, options) {
         if(code) {
             code = escapeSwigTag(code);
             const lines = code.split('\n');
-
-            let content = '';
+            let content = "";
+            let comment_pre = "";
+            let add_or_not = false;
 
             for (let i = 0, len = lines.length; i < len; i++) {
                 let line = lines[i];
-                let append = '';
+                let lineno = Number(firstLine) + i;
+                let index = -1;
+    
+                if( !add_or_not  && -1 != (index = line.indexOf('<span class="token comment">'))){ 
+                    comment_pre = '<span class="token comment">';
 
-                let lineno = Number(firstLine) + i
+                    if(-1 == line.lastIndexOf("</span>")){
+                        line += "</span>";
+                        add_or_not = true;
+                    } else { add_or_not = false; }
+                }
+                else if(add_or_not){
+                    line = comment_pre + line;
+
+                    if(-1 == line.lastIndexOf("</span>")){
+                        line += "</span>";
+                        add_or_not = true;
+                    } else { add_or_not = false; }
+                } else { comment_pre = ""; }
 
                 if (mark && mark.includes(lineno)) {
                     content += `<tr class="marked">`;
@@ -100,9 +117,7 @@ module.exports = function (md, options) {
             let result = `<figure class="highlight${langToUse ? ` ${langToUse}` : ''}">`;
 
             result += `<figcaption data-lang="${langShow ? langShow:''}">${caption}</figcaption>`;
-
             result += `<table>${content}</table></figure>`;
-
             return result;
         }
 


### PR DESCRIPTION
修复C/C++代码高亮时，C风格(/**/)内部注释无效。当使用C风格注释时，多行注释只有一行有效，这里模仿了高亮逻辑，通过手动判断是否是注释，当确认是注释时添加注释标签。